### PR TITLE
Implement media routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+- '4'
+- '6'
+- '8'
+notifications:
+  email: false

--- a/api.js
+++ b/api.js
@@ -76,7 +76,7 @@ Api.prototype.mediaPost = function (req, res, m) {
   res.setHeader('content-type', 'application/json')
   req.pipe(this.media.createWriteStream(id))
     .once('finish', function () {
-      res.end(JSON.stringify({id: id, type: mime}))
+      res.end(JSON.stringify({id: id}))
     })
     .once('error', function (err) {
       res.statusCode = 500

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   },
   "devDependencies": {
     "abstract-blob-store": "^3.3.4",
+    "concat-stream": "^1.6.2",
+    "hyperquest": "^2.1.3",
     "memdb": "^1.3.1",
     "random-access-memory": "^2.4.0",
     "standard": "^11.0.1",

--- a/test/media.js
+++ b/test/media.js
@@ -1,12 +1,35 @@
 var test = require('tape')
-var http = require('http')
+var hyperquest = require('hyperquest')
 var createServer = require('./server')
+var concat = require('concat-stream')
 
 test('media: upload', function (t) {
-  createServer(function (server, url) {
-    console.log('url', url)
-    server.close()
-    t.end()
+  createServer(function (server, base) {
+    var href = base + '/media'
+
+    var image1x1 = new Buffer('89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de000000097048597300000b1300000b1301009a9c180000000774494d4507e204141320381e45f7340000001d69545874436f6d6d656e7400000000004372656174656420776974682047494d50642e65070000000c4944415408d763f8ffff3f0005fe02fedccc59e70000000049454e44ae426082', 'hex')
+
+    var hq = hyperquest.post(href, {
+      headers: { 'content-type': 'image/png' }
+    })
+
+    // http response
+    hq.once('response', function (res) {
+      t.equal(res.statusCode, 200, 'create 200 ok')
+      t.equal(res.headers['content-type'], 'application/json', 'type correct')
+    })
+
+    // response content
+    hq.pipe(concat({ encoding: 'string' }, function (body) {
+      var obj = JSON.parse(body)
+      t.ok(/^[0-9A-Fa-f]+$/.test(obj.id), 'expected media id response')
+
+      server.close()
+      t.end()
+    }))
+
+    // request
+    hq.end(image1x1)
   })
 })
 

--- a/test/server.js
+++ b/test/server.js
@@ -20,7 +20,7 @@ module.exports = function (cb) {
   var router = Router(osm, media)
 
   var server = http.createServer(function (req, res) {
-    if (route(req, res)) {
+    if (router(req, res)) {
     } else {
       res.statusCode = 404
       res.end('not found\n')


### PR DESCRIPTION
This adds the `PUT /media` and `GET /media/:id` routes, plus an integration/server test for each.

..I started writing this on master and then I realized "oh wait let's NOT be pushing random WIP stuff onto master, because COLLABORATION". So check out these commits on master as well:

- POST: 5ecefa99eeabab056e4ab3e389b9188f8a098ae6
- GET: 08e00c60c59d9fb732eefba8a61fa23ec0103f0d
- Pass in media store as a blob: dc7bf95ebd8a79993cf368145f30e79932a4682b
- Test server: 4d3f15bc820ee46c350b86ed13ef52b6012b4a5b

In the future: fewer of hot mess PRs. :sunny: